### PR TITLE
Integrate with SPA

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -32,6 +32,8 @@ export async function handleRequest(
 ): Promise<AuthResponse> {
   // CHANGE: handle different naming
   // event.methodArn = event.routeArn
+  // event.httpMethod = event.requestContext.http.method
+  // event.path = event.rawPath
 
   const singleValueHeaders = event.headers || {}
   const originFromHeader = singleValueHeaders['origin'] || singleValueHeaders['Origin'] || ''


### PR DESCRIPTION
Differences:
- Lambda is called with `routeArn` instead
- Return value of the Lambda Authorizer requires `principalId` to be `user`
- Azure AD does not have introspection URL
- Our architecture already returns both ID and access token